### PR TITLE
Implement event hash versioning

### DIFF
--- a/electrumx/__init__.py
+++ b/electrumx/__init__.py
@@ -2,6 +2,7 @@ __version__ = "0.1.0"
 version = f'gaze-electrumx-v{__version__}'
 version_short = __version__
 gaze_db_version = 1
+gaze_event_hash_version = 1
 
 from electrumx.server.controller import Controller
 from electrumx.server.env import Env

--- a/electrumx/server/gaze_network_report_client.py
+++ b/electrumx/server/gaze_network_report_client.py
@@ -32,6 +32,7 @@ class GazeNetworkReportClient:
             'type': type,
             'clientVersion': electrumx.version,
             'dbVersion': electrumx.gaze_db_version,
+            'eventHashVersion': electrumx.gaze_event_hash_version,
             'network': self.env.coin.NET,
             'blockHeight': height,
             'blockHash': block_hash.hex(),


### PR DESCRIPTION
# Summary
1. Implement event hash versioning for when we change our event hash logic and therefore invalidates all event hashes in DB. The client now checks if the event hash version in DB matches the one that it supports, and direct the user to reindex the database if it doesn't.