### PR TITLE
Wrap type hints in strings to support python versions 3.8.x and below

### DIFF
--- a/electrumx/lib/atomicals_blueprint_builder.py
+++ b/electrumx/lib/atomicals_blueprint_builder.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
    from typing import Literal
 
 class FtColoringSummary:
-  def __init__(self, atomical_id_to_expected_outs_map: 'dict[bytes, ExpectedOutputSet]', fts_burned: dict[bytes, float], cleanly_assigned: bool, atomicals_list: 'list[AtomicalInputSummary]'):
+  def __init__(self, atomical_id_to_expected_outs_map: 'dict[bytes, ExpectedOutputSet]', fts_burned: 'dict[bytes, float]', cleanly_assigned: bool, atomicals_list: 'list[AtomicalInputSummary]'):
     self.atomical_id_to_expected_outs_map = atomical_id_to_expected_outs_map
     self.cleanly_assigned = cleanly_assigned
     self.fts_burned = fts_burned
@@ -65,9 +65,9 @@ def calculate_outputs_to_color_for_ft_atomical_ids(tx, ft_atomicals, sort_by_fif
         # return FtColoringSummary(potential_atomical_ids_to_output_idxs_map, fts_burned, not non_clean_output_slots, atomical_list)
     atomical_list = order_ft_inputs(ft_atomicals, sort_by_fifo)
     next_start_out_idx = 0
-    potential_atomical_ids_to_output_idxs_map: dict[bytes, ExpectedOutputSet] = {}
+    potential_atomical_ids_to_output_idxs_map: 'dict[bytes, ExpectedOutputSet]' = {}
     non_clean_output_slots = False
-    fts_burned: dict[bytes, float] = {}
+    fts_burned: 'dict[bytes, float]' = {}
     for item in atomical_list:
       atomical_id = item.atomical_id
       # If a target exponent was provided, then use that instead
@@ -118,7 +118,7 @@ class AtomicalInputSummary:
     self.type = atomical_type
     self.total_satsvalue = 0 
     self.total_tokenvalue = 0
-    self.input_indexes: list[AtomicalInputItem] = []
+    self.input_indexes: 'list[AtomicalInputItem]' = []
     self.max_exponent = 0
     self.mint_info = mint_info
 
@@ -146,7 +146,7 @@ class AtomicalColoredOutputNft:
     self.input_summary_info = input_summary_info  
     
 class AtomicalFtOutputBlueprintAssignmentSummary:
-  def __init__(self, outputs: "dict[int, dict[Literal['atomicals'], dict[bytes, AtomicalColoredOutputFt]]]", fts_burned: dict[bytes, float], cleanly_assigned: bool, first_atomical_id: bytes):
+  def __init__(self, outputs: "dict[int, dict[Literal['atomicals'], dict[bytes, AtomicalColoredOutputFt]]]", fts_burned: 'dict[bytes, float]', cleanly_assigned: bool, first_atomical_id: bytes):
     self.outputs = outputs 
     self.fts_burned = fts_burned
     self.cleanly_assigned = cleanly_assigned
@@ -156,8 +156,8 @@ class AtomicalNftOutputBlueprintAssignmentSummary:
   def __init__(self, outputs: "dict[int, dict[Literal['atomicals'], dict[bytes, AtomicalInputSummary]]]"):
     self.outputs = outputs 
 
-def order_ft_inputs(ft_atomicals: dict[bytes, AtomicalInputSummary], sort_by_fifo):
-  atomical_list: list[AtomicalInputSummary] = []
+def order_ft_inputs(ft_atomicals: 'dict[bytes, AtomicalInputSummary]', sort_by_fifo):
+  atomical_list: 'list[AtomicalInputSummary]' = []
   # If sorting is by FIFO, then get the mappng of which FTs are at which inputs
   if sort_by_fifo:
     input_idx_map = {}
@@ -404,7 +404,7 @@ class AtomicalsTransferBlueprintBuilder:
   # Builds a map and image of all the inputs and their satvalue and tokenvalue (adjusted by exponent)
   # This is the base datastructure used to color FT outputs and determine what exact satvalue will be needed to maintain input token value to outputs
   @classmethod
-  def build_atomical_input_summaries(cls, get_atomicals_id_mint_info, map_atomical_ids_to_summaries: dict[bytes, AtomicalInputSummary], atomicals_entry_list, txin_index):
+  def build_atomical_input_summaries(cls, get_atomicals_id_mint_info, map_atomical_ids_to_summaries: 'dict[bytes, AtomicalInputSummary]', atomicals_entry_list, txin_index):
       atomicals_id_mint_info_map = {}
       # For each input atomical spent at the current input...
       for atomicals_entry in atomicals_entry_list:
@@ -431,14 +431,14 @@ class AtomicalsTransferBlueprintBuilder:
   
   @classmethod
   def build_atomical_input_summaries_by_type(cls, get_atomicals_id_mint_info, atomicals_spent_at_inputs):
-      map_atomical_ids_to_summaries: dict[bytes, AtomicalInputSummary] = {}
+      map_atomical_ids_to_summaries: 'dict[bytes, AtomicalInputSummary]' = {}
       for txin_index, atomicals_entry_list in atomicals_spent_at_inputs.items():
           # Accumulate the total input value by atomical_id
           # The value will be used below to determine the amount of input we can allocate for FT's
           AtomicalsTransferBlueprintBuilder.build_atomical_input_summaries(get_atomicals_id_mint_info, map_atomical_ids_to_summaries, atomicals_entry_list, txin_index)
       # Group the atomicals by NFT and FT for easier handling
-      nft_atomicals: dict[bytes, AtomicalInputSummary] = {}
-      ft_atomicals: dict[bytes, AtomicalInputSummary] = {}
+      nft_atomicals: 'dict[bytes, AtomicalInputSummary]' = {}
+      ft_atomicals: 'dict[bytes, AtomicalInputSummary]' = {}
       for atomical_id, mint_info in map_atomical_ids_to_summaries.items(): 
           if mint_info.type == 'NFT':
               nft_atomicals[atomical_id] = mint_info

--- a/electrumx/server/db.py
+++ b/electrumx/server/db.py
@@ -77,7 +77,7 @@ class FlushData:
     general_adds = attr.ib()            # type: List[Tuple[Sequence[bytes], Sequence[bytes]]]
     # realm_adds map realm names to tx_num ints, which then map onto an atomical_id
     # The purpose is to track the earliest appearance of a realm name claim request in the order of the commit tx number
-    realm_adds = attr.ib()              # type: Dict[bytes, Dict[int, bytes]
+    realm_adds = attr.ib()              # type: Dict[bytes, Dict[int, bytes]]
     # container_adds map container names to tx_num ints, which then map onto an atomical_id
     # The purpose is to track the earliest appearance of a container name claim request in the order of the commit tx number
     container_adds = attr.ib()          # type: List[Tuple[Sequence[bytes], Sequence[bytes]]]
@@ -85,21 +85,21 @@ class FlushData:
     # The purpose is to track the earliest appearance of a ticker name claim request in the order of the commit tx number
     ticker_adds = attr.ib()             # type: List[Tuple[Sequence[bytes], Sequence[bytes]]]
     # subrealm_adds maps parent_realm_id + subrealm name to tx_num ints, which then map onto an atomical_id
-    subrealm_adds = attr.ib()           # type: Dict[bytes, Dict[int, bytes]
+    subrealm_adds = attr.ib()           # type: Dict[bytes, Dict[int, bytes]]
     # subrealmpay_adds maps atomical_id to tx_num ints, which then map onto payment_outpoints
-    subrealmpay_adds = attr.ib()           # type: Dict[bytes, Dict[int, bytes]
+    subrealmpay_adds = attr.ib()           # type: Dict[bytes, Dict[int, bytes]]
     # dmitem_adds maps parent_realm_id + dmitem name to tx_num ints, which then map onto an atomical_id
-    dmitem_adds = attr.ib()           # type: Dict[bytes, Dict[int, bytes]
+    dmitem_adds = attr.ib()           # type: Dict[bytes, Dict[int, bytes]]
     # dmpay_adds maps atomical_id to tx_num ints, which then map onto payment_outpoints
-    dmpay_adds = attr.ib()           # type: Dict[bytes, Dict[int, bytes]
+    dmpay_adds = attr.ib()           # type: Dict[bytes, Dict[int, bytes]]
     # distmint_adds tracks the b'gi' which is the initial distributed mint location tracked to determine if any more mints are allowed
     # It maps atomical_id (of the dft deploy token mint) to location_ids and then the details of the scripthash+value_sats of the mint        
-    distmint_adds = attr.ib()           # type: Dict[bytes, Dict[bytes, bytes]
+    distmint_adds = attr.ib()           # type: Dict[bytes, Dict[bytes, bytes]]
     # state_adds is for evt, mod state updates
     # It maps atomical_id to the data of the state update      
-    state_adds = attr.ib()           # type: Dict[bytes, Dict[bytes, bytes]
+    state_adds = attr.ib()           # type: Dict[bytes, Dict[bytes, bytes]]
     # op_adds is for record tx operation of one tx
-    op_adds = attr.ib()   # type: Dict[bytes, Dict[bytes]
+    op_adds = attr.ib()   # type: Dict[bytes, Dict[bytes]]
     
 COMP_TXID_LEN = 4
 

--- a/electrumx/server/http_opi.py
+++ b/electrumx/server/http_opi.py
@@ -56,9 +56,9 @@ def tx_contains_atomical_id(tx_data, atomical_id):
 
 @dataclass
 class BalanceQuery:
-    address: str | None
-    atomical_id: bytes | None
-    block_height: int | None
+    address: 'str | None'
+    atomical_id: 'bytes | None'
+    block_height: 'int | None'
 
 class HttpOPIHandler(object):
     def __init__(self, session_mgr: 'SessionManager', env: 'Env', db: DB, bp: BlockProcessor, http_handler: HttpHandler):

--- a/electrumx/server/http_opi.py
+++ b/electrumx/server/http_opi.py
@@ -101,7 +101,7 @@ class HttpOPIHandler(object):
             'block_height': block_height
         })
     
-    def _process_balance(self, address: str, balances: dict[bytes, int], tx_data):
+    def _process_balance(self, address: str, balances: 'dict[bytes, int]', tx_data):
         inputs = tx_data['transfers']['inputs']
         outputs = tx_data['transfers']['outputs']
         for _, v in inputs.items():
@@ -134,7 +134,7 @@ class HttpOPIHandler(object):
     async def _get_populated_arc20_balances(self, address: str, atomical_id: 'bytes | None', block_height: int):
         pk_scriptb = get_script_from_address(address)
 
-        balances: dict[bytes, int] = {} # atomical_id -> amount (int)
+        balances: 'dict[bytes, int]' = {} # atomical_id -> amount (int)
         script_hash = sha256(pk_scriptb)
         hashX = scripthash_to_hashX(script_hash)
         if not hashX:
@@ -161,7 +161,7 @@ class HttpOPIHandler(object):
         atomicals_list = await asyncio.gather(*[self._get_atomical(atomical_id) for atomical_id in atomical_ids])
         atomicals = {atomical_id: atomical for atomical_id, atomical in zip(atomical_ids, atomicals_list)}
 
-        populated_balances: dict[str, dict] = {} # atomical_id -> { "amount": int, "ticker": str | None }
+        populated_balances: 'dict[str, dict]' = {} # atomical_id -> { "amount": int, "ticker": str | None }
         for atomical_id, amount in balances.items():
             atomical = atomicals.get(atomical_id)
             if atomical:
@@ -209,10 +209,10 @@ class HttpOPIHandler(object):
     @error_handler
     async def get_arc20_balances_batch(self, request: 'Request') -> 'Response':
         body = await request.json()
-        queries: list[BalanceQuery] = []
+        queries: 'list[BalanceQuery]' = []
         latest_block_height = self.db.db_height
 
-        raw_queries: list[dict] = body.get('queries', [])
+        raw_queries: 'list[dict]' = body.get('queries', [])
         for idx, raw_query in enumerate(raw_queries):
             address = raw_query.get('address')
             pk_script = raw_query.get('pk_script')

--- a/electrumx/server/mempool.py
+++ b/electrumx/server/mempool.py
@@ -173,7 +173,7 @@ class MemPool:
 
     @classmethod
     def _compress_histogram(
-            cls, histogram: Dict[float, int], *, bin_size: int
+            cls, histogram: 'dict[float, int]', *, bin_size: int
     ) -> Sequence[Tuple[float, int]]:
         '''Calculate and return a compact fee histogram as needed for
         "mempool.get_fee_histogram" protocol request.


### PR DESCRIPTION
# Summary
Currently, some of the code breaks when running python 3.8 or below due to type hint formats. Wrapping those in strings should fix this problem.